### PR TITLE
Make `cargo wapm`'s CLI args match `cargo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
+ "clap-cargo",
  "serde",
  "toml",
  "tracing",
@@ -99,6 +100,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca953650a7350560b61db95a0ab1d9c6f7b74d146a9e08fb258b834f3cf7e2c"
+dependencies = [
+ "cargo_metadata",
+ "clap",
+ "doc-comment",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +131,12 @@ checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "half"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.56"
 anyhow = "1"
 cargo_metadata = "0.15"
 clap = { version = "4", features = ["derive", "env"] }
+clap-cargo = { version = "0.10.0", features = ["cargo_metadata"] }
 serde = "1"
 toml = "0.5"
 tracing = { version = "0.1.34", features = ["attributes"] }

--- a/src/bin/cargo-wapm.rs
+++ b/src/bin/cargo-wapm.rs
@@ -24,5 +24,6 @@ fn main() -> Result<(), Error> {
 #[derive(Debug, Parser)]
 #[clap(name = "cargo", bin_name = "cargo", version, author)]
 enum Cargo {
+    #[clap(alias = "wasmer")]
     Wapm(Publish),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-mod metadata;
+pub mod metadata;
+mod pack;
 mod publish;
 
-pub use crate::{
-    metadata::{Features, MetadataTable, Wapm},
-    publish::Publish,
-};
+pub use crate::{pack::Pack, publish::Publish};

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,10 +1,5 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, path::PathBuf};
 
-use anyhow::Error;
-use cargo_metadata::{CargoOpt, Metadata, MetadataCommand};
 use wapm_toml::Bindings;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -23,51 +18,6 @@ pub struct Wapm {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fs: Option<HashMap<String, PathBuf>>,
     pub bindings: Option<Bindings>,
-}
-
-#[tracing::instrument(skip_all)]
-pub(crate) fn parse_cargo_toml(
-    manifest_path: Option<&Path>,
-    no_default_features: bool,
-    features: Option<&Features>,
-    all_features: bool,
-) -> Result<Metadata, Error> {
-    let mut cmd = MetadataCommand::new();
-
-    if let Some(manifest_path) = manifest_path {
-        cmd.manifest_path(manifest_path);
-    }
-
-    if let Ok(path) = std::env::current_dir() {
-        cmd.current_dir(path);
-    }
-
-    if no_default_features {
-        cmd.features(CargoOpt::NoDefaultFeatures);
-    }
-
-    if let Some(features) = features {
-        cmd.features(CargoOpt::SomeFeatures(features.0.clone()));
-    }
-
-    if all_features {
-        cmd.features(CargoOpt::AllFeatures);
-    }
-
-    tracing::debug!(cmd = ?cmd.cargo_command(), "Parsing Cargo metadata");
-
-    let meta = cmd.exec()?;
-
-    Ok(meta)
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Features(pub Vec<String>);
-
-impl From<&'_ str> for Features {
-    fn from(value: &'_ str) -> Self {
-        Features(value.split(',').map(|s| s.to_string()).collect())
-    }
 }
 
 #[cfg(test)]

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,0 +1,353 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, Error};
+use cargo_metadata::{Metadata, Package, Target};
+use clap::Parser;
+use serde::Deserialize;
+use wapm_toml::{Manifest, Module};
+
+use crate::metadata::MetadataTable;
+
+/// Compile a Rust crate to a WAPM package.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use clap::Parser;
+/// use cargo_wapm::Pack;
+///
+/// # fn main() -> Result<(), anyhow::Error> {
+/// let pack = Pack::parse();
+/// let meta = pack.metadata()?;
+///
+/// for pkg in pack.resolve_packages(&meta) {
+///     let dest = pack.generate_wapm_package(pkg, meta.target_directory.as_ref())?;
+///     println!("Wrote the WAPM package for {} to {}", pkg.name, dest.display());
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Parser)]
+pub struct Pack {
+    #[command(flatten)]
+    manifest: clap_cargo::Manifest,
+    #[command(flatten)]
+    workspace: clap_cargo::Workspace,
+    #[command(flatten)]
+    features: clap_cargo::Features,
+    /// Compile in debug mode.
+    #[clap(long)]
+    pub debug: bool,
+    /// Where to save the compiled WAPM packages (defaults to "$target_dir/wapm/")
+    #[clap(long, env)]
+    out_dir: Option<PathBuf>,
+}
+
+impl Pack {
+    /// Use the `cargo metadata` subcommand to learn about the workspace.
+    #[tracing::instrument(skip_all)]
+    pub fn metadata(&self) -> Result<Metadata, Error> {
+        let mut cmd = self.manifest.metadata();
+        self.features.forward_metadata(&mut cmd);
+        let meta = cmd.exec()?;
+
+        Ok(meta)
+    }
+
+    /// Figure out which packages the user wants to pack.
+    #[tracing::instrument(skip_all)]
+    pub fn resolve_packages<'meta>(&self, metadata: &'meta Metadata) -> Vec<&'meta Package> {
+        let (packages, _excluded) = self.workspace.partition_packages(metadata);
+        packages
+    }
+
+    /// Compile a crate to a WAPM package and save it on disk.
+    #[tracing::instrument(skip_all)]
+    pub fn generate_wapm_package(
+        &self,
+        pkg: &Package,
+        target_dir: &Path,
+    ) -> Result<PathBuf, Error> {
+        let dest = self
+            .out_dir
+            .as_deref()
+            .unwrap_or(target_dir)
+            .join(&pkg.name);
+        tracing::debug!(dest=%dest.display(), "Generating the WAPM package");
+
+        if dest.exists() {
+            tracing::debug!(
+                dir=%dest.display(),
+                "Removing previous generated package",
+            );
+            std::fs::remove_dir_all(&dest)
+                .with_context(|| format!("Unable to remove \"{}\"", dest.display()))?;
+        }
+
+        let target = determine_target(pkg)?;
+        let manifest: Manifest = generate_manifest(pkg, target)?;
+        let modules = manifest
+            .module
+            .as_deref()
+            .expect("We will always compile one module");
+        let wasm_path = self.compile_to_wasm(pkg, target_dir, &modules[0], target)?;
+        pack(&dest, &manifest, &wasm_path, pkg)?;
+
+        Ok(dest)
+    }
+
+    fn compile_to_wasm(
+        &self,
+        pkg: &Package,
+        target_dir: &Path,
+        module: &Module,
+        target: &Target,
+    ) -> Result<PathBuf, Error> {
+        let mut cmd = Command::new(cargo_bin());
+        let target_triple = match module.abi {
+            wapm_toml::Abi::Emscripten => "wasm32-unknown-emscripten",
+            wapm_toml::Abi::Wasi => "wasm32-wasi",
+            wapm_toml::Abi::None | wapm_toml::Abi::WASM4 => "wasm32-unknown-unknown",
+        };
+
+        cmd.arg("build")
+            .arg("--quiet")
+            .args(["--manifest-path", pkg.manifest_path.as_str()])
+            .args(["--target", target_triple]);
+
+        let clap_cargo::Features {
+            all_features,
+            no_default_features,
+            ref features,
+            ..
+        } = self.features;
+        if all_features {
+            cmd.arg("--all-features");
+        }
+        if no_default_features {
+            cmd.arg("--no-default-features");
+        }
+        if !features.is_empty() {
+            cmd.arg(format!("--features={}", self.features.features.join(",")));
+        }
+
+        if !self.debug {
+            cmd.arg("--release");
+        }
+
+        tracing::debug!(?cmd, "Compiling the WebAssembly package");
+
+        let status = cmd.status().with_context(|| {
+            format!(
+                "Unable to start \"{}\". Is it installed?",
+                cmd.get_program().to_string_lossy()
+            )
+        })?;
+
+        if !status.success() {
+            match status.code() {
+                Some(code) => anyhow::bail!("Cargo exited unsuccessfully with exit code {}", code),
+                None => anyhow::bail!("Cargo exited unsuccessfully"),
+            }
+        }
+
+        let binary = target_dir
+            .join(target_triple)
+            .join(if self.debug { "debug" } else { "release" })
+            .join(wasm_binary_name(target))
+            .with_extension("wasm");
+
+        anyhow::ensure!(
+            binary.exists(),
+            "Expected \"{}\" to exist",
+            binary.display()
+        );
+
+        Ok(binary)
+    }
+}
+
+fn determine_target(pkg: &Package) -> Result<&Target, Error> {
+    let candidates: Vec<_> = pkg
+        .targets
+        .iter()
+        .filter(|t| is_webassembly_library(t) || t.is_bin())
+        .collect();
+    match *candidates.as_slice() {
+        [single_target] => Ok(single_target),
+        [] => anyhow::bail!(
+            "The {} package doesn't contain any binaries or \"cdylib\" libraries",
+            pkg.name
+        ),
+        [..] => anyhow::bail!(
+            "Unable to decide what to publish. Expected one executable or \"cdylib\" library, but found {}",
+            candidates.iter()
+                .map(|t| format!("{} ({:?})", t.name, t.kind))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn is_webassembly_library(target: &Target) -> bool {
+    target.kind.iter().any(|k| k == "cdylib")
+}
+
+#[tracing::instrument(skip_all)]
+fn pack(dest: &Path, manifest: &Manifest, wasm_path: &Path, pkg: &Package) -> Result<(), Error> {
+    std::fs::create_dir_all(dest)
+        .with_context(|| format!("Unable to create the \"{}\" directory", dest.display()))?;
+
+    let manifest_path = dest.join("wapm.toml");
+    let toml = toml::to_string(manifest).context("Unable to serialize the wapm.toml")?;
+    tracing::debug!(
+        path = %manifest_path.display(),
+        bytes = toml.len(),
+        "Writing manifest",
+    );
+    std::fs::write(&manifest_path, toml.as_bytes())
+        .with_context(|| format!("Unable to write to \"{}\"", manifest_path.display()))?;
+
+    let new_wasm_path = dest.join(wasm_path.file_name().unwrap());
+    copy(wasm_path, new_wasm_path)?;
+
+    let base_dir = pkg.manifest_path.parent().unwrap();
+
+    if let Some(license_file) = pkg.license_file.as_ref() {
+        let license_file = base_dir.join(license_file);
+        let dest = dest.join(Path::new(&license_file).file_name().unwrap());
+        copy(license_file, dest)?;
+    }
+
+    if let Some(readme) = pkg.readme.as_ref() {
+        let readme = base_dir.join(readme);
+        let dest = dest.join(readme.file_name().unwrap());
+        copy(readme, dest)?;
+    }
+
+    for module in manifest.module.as_deref().unwrap_or_default() {
+        if let Some(bindings) = &module.bindings {
+            let base_dir = base_dir.as_std_path();
+            for path in bindings.referenced_files(base_dir)? {
+                // Note: we want to maintain the same location relative to the
+                // Cargo.toml file
+                let relative_path = path.strip_prefix(base_dir).with_context(|| {
+                    format!(
+                        "\"{}\" should be inside \"{}\"",
+                        path.display(),
+                        base_dir.display(),
+                    )
+                })?;
+                let dest = dest.join(relative_path);
+                copy(path, dest)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), Error> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+
+    tracing::debug!(
+        from = %from.display(),
+        to = %to.display(),
+        "Copying file",
+    );
+    std::fs::copy(from, to).with_context(|| {
+        format!(
+            "Unable to copy \"{}\" to \"{}\"",
+            from.display(),
+            to.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+fn wasm_binary_name(target: &Target) -> String {
+    // Because reasons, `rustc` will leave dashes in a binary's name but
+    // libraries are converted to underscores.
+    if target.is_bin() {
+        target.name.clone()
+    } else {
+        target.name.replace('-', "_")
+    }
+}
+
+fn cargo_bin() -> String {
+    std::env::var("CARGO").unwrap_or_else(|_| String::from("cargo"))
+}
+
+#[tracing::instrument(skip_all)]
+fn generate_manifest(pkg: &Package, target: &Target) -> Result<Manifest, Error> {
+    tracing::trace!(?target, "Generating manifest");
+
+    let MetadataTable {
+        wapm:
+            crate::metadata::Wapm {
+                wasmer_extra_flags,
+                fs,
+                abi,
+                namespace,
+                package,
+                bindings,
+            },
+    } = MetadataTable::deserialize(&pkg.metadata)
+        .context("Unable to deserialize the [metadata] table")?;
+
+    match pkg.description.as_deref() {
+        Some("") => anyhow::bail!("The \"description\" field in your Cargo.toml is empty"),
+        Some(_) => {}
+        None => anyhow::bail!("The \"description\" field in your Cargo.toml wasn't set"),
+    }
+
+    let package_name = format!("{}/{}", namespace, package.as_deref().unwrap_or(&pkg.name));
+
+    let module = Module {
+        name: target.name.clone(),
+        source: PathBuf::from(wasm_binary_name(target)).with_extension("wasm"),
+        abi,
+        bindings,
+        interfaces: None,
+        kind: None,
+    };
+
+    let command = if target.is_bin() {
+        let cmd = wapm_toml::Command::V1(wapm_toml::CommandV1 {
+            module: target.name.clone(),
+            name: target.name.clone(),
+            package: Some(package_name.clone()),
+            main_args: None,
+        });
+        Some(vec![cmd])
+    } else {
+        None
+    };
+
+    Ok(Manifest {
+        package: wapm_toml::Package {
+            name: package_name,
+            version: pkg.version.clone(),
+            description: pkg.description.clone().unwrap_or_default(),
+            license: pkg.license.clone(),
+            license_file: pkg.license_file().map(|p| p.into_std_path_buf()),
+            readme: pkg.readme().map(|p| p.into_std_path_buf()),
+            repository: pkg.repository.clone(),
+            homepage: pkg.homepage.clone(),
+            wasmer_extra_flags,
+            disable_command_rename: false,
+            rename_commands_to_raw_command_name: false,
+        },
+        module: Some(vec![module]),
+        command,
+        fs,
+        dependencies: None,
+        base_directory_path: PathBuf::new(),
+    })
+}

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -1,116 +1,49 @@
-use std::{
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{path::Path, process::Command};
 
 use anyhow::{Context, Error};
-use cargo_metadata::{Metadata, Package, Target};
+use cargo_metadata::Package;
 use clap::Parser;
-use serde::Deserialize;
-use wapm_toml::{Manifest, Module};
 
-use crate::{metadata::Features, MetadataTable, Wapm};
+use crate::Pack;
 
 /// Publish a crate to the WebAssembly Package Manager.
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
 pub struct Publish {
     /// Build the package, but don't publish it.
     #[clap(short, long, env)]
     pub dry_run: bool,
-    /// Path to Cargo.toml
-    #[clap(long, env)]
-    pub manifest_path: Option<PathBuf>,
-    /// Publish every crate in this workspace
-    #[clap(short, long, env)]
-    pub workspace: bool,
-    /// A comma-delimited list of features to enable.
-    #[clap(long)]
-    pub features: Option<Features>,
-    /// Compile with all features enabled.
-    #[clap(long)]
-    pub all_features: bool,
-    /// Do not activate the `default` feature while compiling.
-    #[clap(long)]
-    pub no_default_features: bool,
-    /// Packages to ignore.
-    #[clap(long)]
-    pub exclude: Vec<String>,
-    /// Compile in debug mode.
-    #[clap(long)]
-    pub debug: bool,
+    #[clap(flatten)]
+    pub pack: Pack,
 }
 
 impl Publish {
     /// Run the [`Publish`] command.
     pub fn execute(self) -> Result<(), Error> {
-        let metadata = crate::metadata::parse_cargo_toml(
-            self.manifest_path.as_deref(),
-            self.no_default_features,
-            self.features.as_ref(),
-            self.all_features,
-        )
-        .context("Unable to parse the workspace's metadata")?;
+        let metadata = self
+            .pack
+            .metadata()
+            .context("Unable to parse the workspace's metadata")?;
 
-        let current_dir =
-            std::env::current_dir().context("Unable to determine the current directory")?;
-
-        let packages_to_publish =
-            determine_crates_to_publish(&metadata, self.workspace, &current_dir, &self.exclude)
-                .context("Unable to determine which crates to publish")?;
-
-        let dir = metadata.target_directory.join("wapm");
-
-        tracing::debug!(%dir, "Clearing the output directory");
+        let packages_to_publish = self.pack.resolve_packages(&metadata);
 
         for pkg in packages_to_publish {
-            let dest: PathBuf = dir.join(&pkg.name).into();
-            publish(pkg, metadata.target_directory.as_ref(), &dest, &self)
+            self.publish(pkg, metadata.target_directory.as_ref())
                 .with_context(|| format!("Unable to publish \"{}\"", pkg.name))?;
         }
 
         Ok(())
     }
-}
 
-#[tracing::instrument(fields(pkg = pkg.name.as_str()), skip_all)]
-fn publish(pkg: &Package, target_dir: &Path, dir: &Path, args: &Publish) -> Result<(), Error> {
-    tracing::info!(dry_run = args.dry_run, "Publishing");
+    #[tracing::instrument(fields(pkg = pkg.name.as_str()), skip_all)]
+    fn publish(&self, pkg: &Package, target_dir: &Path) -> Result<(), Error> {
+        tracing::info!(dry_run = self.dry_run, "Getting ready to publish");
 
-    let target = determine_target(pkg)?;
-    let manifest: Manifest = generate_manifest(pkg, target)?;
-    let modules = manifest
-        .module
-        .as_deref()
-        .expect("We will always compile one module");
-    let wasm_path = compile_to_wasm(pkg, target_dir, args.debug, &modules[0], target)?;
-    pack(dir, &manifest, &wasm_path, pkg)?;
-    upload_to_wapm(dir, args.dry_run)?;
+        let dest = self.pack.generate_wapm_package(pkg, target_dir)?;
+        upload_to_wapm(&dest, self.dry_run)?;
 
-    tracing::info!("Published!");
+        tracing::info!("Published!");
 
-    Ok(())
-}
-
-fn determine_target(pkg: &Package) -> Result<&Target, Error> {
-    let candidates: Vec<_> = pkg
-        .targets
-        .iter()
-        .filter(|t| is_webassembly_library(t) || is_binary(t))
-        .collect();
-    match *candidates.as_slice() {
-        [single_target] => Ok(single_target),
-        [] => anyhow::bail!(
-            "The {} package doesn't contain any binaries or \"cdylib\" libraries",
-            pkg.name
-        ),
-        [..] => anyhow::bail!(
-            "Unable to decide what to publish. Expected one executable or \"cdylib\" library, but found {}",
-            candidates.iter()
-                .map(|t| format!("{} ({:?})", t.name, t.kind))
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
+        Ok(())
     }
 }
 
@@ -144,290 +77,4 @@ fn upload_to_wapm(dir: &Path, dry_run: bool) -> Result<(), Error> {
     }
 
     Ok(())
-}
-
-#[tracing::instrument(skip_all)]
-fn pack(dir: &Path, manifest: &Manifest, wasm_path: &Path, pkg: &Package) -> Result<(), Error> {
-    std::fs::create_dir_all(dir)
-        .with_context(|| format!("Unable to create the \"{}\" directory", dir.display()))?;
-
-    let manifest_path = dir.join("wapm.toml");
-    let toml = toml::to_string(manifest).context("Unable to serialize the wapm.toml")?;
-    tracing::debug!(
-        path = %manifest_path.display(),
-        bytes = toml.len(),
-        "Writing manifest",
-    );
-    std::fs::write(&manifest_path, toml.as_bytes())
-        .with_context(|| format!("Unable to write to \"{}\"", manifest_path.display()))?;
-
-    let new_wasm_path = dir.join(wasm_path.file_name().unwrap());
-    copy(wasm_path, new_wasm_path)?;
-
-    let base_dir = pkg.manifest_path.parent().unwrap();
-
-    if let Some(license_file) = pkg.license_file.as_ref() {
-        let license_file = base_dir.join(license_file);
-        let dest = dir.join(Path::new(&license_file).file_name().unwrap());
-        copy(license_file, dest)?;
-    }
-
-    if let Some(readme) = pkg.readme.as_ref() {
-        let readme = base_dir.join(readme);
-        let dest = dir.join(readme.file_name().unwrap());
-        copy(readme, dest)?;
-    }
-
-    for module in manifest.module.as_deref().unwrap_or_default() {
-        if let Some(bindings) = &module.bindings {
-            let base_dir = base_dir.as_std_path();
-            for path in bindings.referenced_files(base_dir)? {
-                // Note: we want to maintain the same location relative to the
-                // Cargo.toml file
-                let relative_path = path.strip_prefix(base_dir).with_context(|| {
-                    format!(
-                        "\"{}\" should be inside \"{}\"",
-                        path.display(),
-                        base_dir.display(),
-                    )
-                })?;
-                let dest = dir.join(relative_path);
-                copy(path, dest)?;
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<(), Error> {
-    let from = from.as_ref();
-    let to = to.as_ref();
-
-    tracing::debug!(
-        from = %from.display(),
-        to = %to.display(),
-        "Copying file",
-    );
-    std::fs::copy(from, to).with_context(|| {
-        format!(
-            "Unable to copy \"{}\" to \"{}\"",
-            from.display(),
-            to.display()
-        )
-    })?;
-
-    Ok(())
-}
-
-fn compile_to_wasm(
-    pkg: &Package,
-    target_dir: &Path,
-    debug: bool,
-    module: &Module,
-    target: &Target,
-) -> Result<PathBuf, Error> {
-    let mut cmd = Command::new(cargo_bin());
-    let target_triple = match module.abi {
-        wapm_toml::Abi::Emscripten => "wasm32-unknown-emscripten",
-        wapm_toml::Abi::Wasi => "wasm32-wasi",
-        wapm_toml::Abi::None | wapm_toml::Abi::WASM4 => "wasm32-unknown-unknown",
-    };
-
-    cmd.arg("build")
-        .arg("--quiet")
-        .args(["--manifest-path", pkg.manifest_path.as_str()])
-        .args(["--target", target_triple]);
-
-    if !debug {
-        cmd.arg("--release");
-    }
-
-    tracing::debug!(?cmd, "Compiling the WebAssembly package");
-
-    let status = cmd.status().with_context(|| {
-        format!(
-            "Unable to start \"{}\". Is it installed?",
-            cmd.get_program().to_string_lossy()
-        )
-    })?;
-
-    if !status.success() {
-        match status.code() {
-            Some(code) => anyhow::bail!("Cargo exited unsuccessfully with exit code {}", code),
-            None => anyhow::bail!("Cargo exited unsuccessfully"),
-        }
-    }
-
-    let binary = target_dir
-        .join(target_triple)
-        .join(if debug { "debug" } else { "release" })
-        .join(wasm_binary_name(target))
-        .with_extension("wasm");
-
-    anyhow::ensure!(
-        binary.exists(),
-        "Expected \"{}\" to exist",
-        binary.display()
-    );
-
-    Ok(binary)
-}
-
-fn wasm_binary_name(target: &Target) -> String {
-    // Because reasons, `rustc` will leave dashes in a binary's name but
-    // libraries are converted to underscores.
-    if is_binary(target) {
-        target.name.clone()
-    } else {
-        target.name.replace('-', "_")
-    }
-}
-
-fn cargo_bin() -> String {
-    std::env::var("CARGO").unwrap_or_else(|_| String::from("cargo"))
-}
-
-fn is_webassembly_library(target: &Target) -> bool {
-    target.kind.iter().any(|k| k == "cdylib")
-}
-
-fn is_binary(target: &Target) -> bool {
-    target.kind.iter().any(|k| k == "bin")
-}
-
-#[tracing::instrument(skip_all)]
-fn generate_manifest(pkg: &Package, target: &Target) -> Result<Manifest, Error> {
-    tracing::trace!(?target, "The target");
-
-    let MetadataTable {
-        wapm:
-            Wapm {
-                wasmer_extra_flags,
-                fs,
-                abi,
-                namespace,
-                package,
-                bindings,
-            },
-    } = MetadataTable::deserialize(&pkg.metadata)
-        .context("Unable to deserialize the [metadata] table")?;
-
-    match pkg.description.as_deref() {
-        Some("") => anyhow::bail!("The \"description\" field in your Cargo.toml is empty"),
-        Some(_) => {}
-        None => anyhow::bail!("The \"description\" field in your Cargo.toml wasn't set"),
-    }
-
-    let package_name = format!("{}/{}", namespace, package.as_deref().unwrap_or(&pkg.name));
-
-    let module = Module {
-        name: target.name.clone(),
-        source: PathBuf::from(wasm_binary_name(target)).with_extension("wasm"),
-        abi,
-        bindings,
-        interfaces: None,
-        kind: None,
-    };
-
-    let command = if is_binary(target) {
-        let cmd = wapm_toml::Command::V1(wapm_toml::CommandV1 {
-            module: target.name.clone(),
-            name: target.name.clone(),
-            package: Some(package_name.clone()),
-            main_args: None,
-        });
-        Some(vec![cmd])
-    } else {
-        None
-    };
-
-    Ok(Manifest {
-        package: wapm_toml::Package {
-            name: package_name,
-            version: pkg.version.clone(),
-            description: pkg.description.clone().unwrap_or_default(),
-            license: pkg.license.clone(),
-            license_file: pkg.license_file().map(|p| p.into_std_path_buf()),
-            readme: pkg.readme().map(|p| p.into_std_path_buf()),
-            repository: pkg.repository.clone(),
-            homepage: pkg.homepage.clone(),
-            wasmer_extra_flags,
-            disable_command_rename: false,
-            rename_commands_to_raw_command_name: false,
-        },
-        module: Some(vec![module]),
-        command,
-        fs,
-        dependencies: None,
-        base_directory_path: PathBuf::new(),
-    })
-}
-
-#[tracing::instrument(skip_all)]
-fn determine_crates_to_publish<'meta>(
-    metadata: &'meta Metadata,
-    workspace: bool,
-    current_dir: &Path,
-    exclude: &[String],
-) -> Result<Vec<&'meta Package>, Error> {
-    tracing::debug!("Determining which crates to publish");
-
-    let all_workspace_members: Vec<_> = metadata
-        .packages
-        .iter()
-        .filter(|pkg| metadata.workspace_members.contains(&pkg.id))
-        .collect();
-
-    if workspace {
-        tracing::debug!("Looking for publishable packages in the workspace");
-        let mut packages = Vec::new();
-
-        for pkg in all_workspace_members {
-            let _span =
-                tracing::debug_span!("Checking package", name = pkg.name.as_str()).entered();
-
-            if exclude.contains(&pkg.name) {
-                tracing::debug!("Explicitly ignoring");
-                continue;
-            }
-
-            if pkg
-                .metadata
-                .as_object()
-                .and_then(|m| m.get("wapm"))
-                .is_none()
-            {
-                tracing::debug!(
-                    "Skipping because it doesn't contain a [package.metadata.wapm] table"
-                );
-                continue;
-            }
-
-            packages.push(pkg);
-        }
-
-        Ok(packages)
-    } else {
-        // We want to find which package to publish based on the user's current
-        // directory, however it's possible that you can have nested packages
-        // so we want to get the most specific one.
-        let mut candidates: Vec<_> = all_workspace_members
-            .into_iter()
-            .filter(|pkg| {
-                let dir = pkg.manifest_path.parent().unwrap();
-                current_dir.starts_with(dir)
-            })
-            .collect();
-        candidates.sort_by_key(|pkg| pkg.manifest_path.components().count());
-
-        if let Some(&pkg) = candidates.last() {
-            Ok(vec![pkg])
-        } else if let Some(root) = metadata.root_package() {
-            // use the "root" package as a default.
-            Ok(vec![root])
-        } else {
-            anyhow::bail!("Unable to determine which package to publish. Either \"cd\" into the crate folder or use the \"--workspace\" flag.");
-        }
-    }
 }


### PR DESCRIPTION
This switches to the `clap_cargo` crate for parsing command-line args like `--workspace`, `--package`, and `--manifest-path`. 

It will help DX by making the CLI more similar to other `cargo` sub-commands, while also getting rid of a bunch of logic where we tried to implement similar functionality (but poorly).