### PR TITLE
Release v0.3.5

### DIFF
--- a/src/bin/cargo-wapm.rs
+++ b/src/bin/cargo-wapm.rs
@@ -1,5 +1,5 @@
 use anyhow::Error;
-use cargo_wapm::Publish;
+use cargo_wapm::Wapm;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
@@ -17,13 +17,13 @@ fn main() -> Result<(), Error> {
     tracing::debug!(?args, "Started");
 
     match args {
-        Cargo::Wapm(p) => p.execute(),
+        Cargo::Wapm(Wapm::Publish(p)) => p.execute(),
     }
 }
 
 #[derive(Debug, Parser)]
 #[clap(name = "cargo", bin_name = "cargo", version, author)]
 enum Cargo {
-    #[clap(alias = "wasmer")]
-    Wapm(Publish),
+    #[clap(subcommand)]
+    Wapm(Wapm),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,11 @@ mod pack;
 mod publish;
 
 pub use crate::{pack::Pack, publish::Publish};
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[clap(author, about, version)]
+pub enum Wapm {
+    Publish(Publish),
+}

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -8,6 +8,7 @@ use crate::Pack;
 
 /// Publish a crate to the WebAssembly Package Manager.
 #[derive(Debug, Parser)]
+#[clap(author, about, version)]
 pub struct Publish {
     /// Build the package, but don't publish it.
     #[clap(short, long, env)]

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -30,7 +30,7 @@ impl Publish {
         for pkg in packages_to_publish {
             // We only want to publish things that have a
             // [package.metadata.wapm] table
-            if has_package_metadata_table(pkg, "wapm") {
+            if !has_package_metadata_table(pkg, "wapm") {
                 tracing::info!(
                     pkg.name = pkg.name,
                     "No [package.metadata.wapm] found in the package. Skipping..."


### PR DESCRIPTION
This fixes a couple minor bugs like `cargo wapm --version` not working and the `[package.metadata.wapm]` filtering being the wrong way around.