### PR TITLE
We want "cargo wapm ...", not "cargo wapm publish ..."

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-wapm"
-version = "0.3.4"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-wapm"
-version = "0.3.4"
+version = "0.3.6"
 authors = [
     "Michael-F-Bryan <michaelfbryan@gmail.com>",
     "Hammer of the Gods <developers@hotg.ai>",

--- a/src/bin/cargo-wapm.rs
+++ b/src/bin/cargo-wapm.rs
@@ -1,5 +1,5 @@
 use anyhow::Error;
-use cargo_wapm::Wapm;
+use cargo_wapm::Publish;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
@@ -17,13 +17,12 @@ fn main() -> Result<(), Error> {
     tracing::debug!(?args, "Started");
 
     match args {
-        Cargo::Wapm(Wapm::Publish(p)) => p.execute(),
+        Cargo::Wapm(p) => p.execute(),
     }
 }
 
 #[derive(Debug, Parser)]
 #[clap(name = "cargo", bin_name = "cargo", version, author)]
 enum Cargo {
-    #[clap(subcommand)]
-    Wapm(Wapm),
+    Wapm(Publish),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,3 @@ mod pack;
 mod publish;
 
 pub use crate::{pack::Pack, publish::Publish};
-
-use clap::Parser;
-
-#[derive(Debug, Parser)]
-#[clap(author, about, version)]
-pub enum Wapm {
-    Publish(Publish),
-}


### PR DESCRIPTION
This reverts part of dddce61 because the `Wapm` enum introduced an extra layer of sub-commands.